### PR TITLE
Fix for #45

### DIFF
--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -38,17 +38,13 @@ class CsvOutput(FileOutput):
                 self._writer = csv.DictWriter(
                     self._log_file,
                     fieldnames=self._fieldnames,
+                    restval='',
                     extrasaction='ignore')
                 self._writer.writeheader()
 
             if to_csv.keys() != self._fieldnames:
                 self._fieldnames |= to_csv.keys()
-                if set(to_csv.keys()).issubset(self._fieldnames):
-                    for key in self._fieldnames:
-                        if key not in to_csv.keys():
-                            to_csv[key] = ''
-                    self._writer.writerow(to_csv)
-                else:
+                if not set(to_csv.keys()).issubset(self._fieldnames):
                     self.add_key()
             else:
                 self._writer.writerow(to_csv)
@@ -77,25 +73,3 @@ class CsvOutput(FileOutput):
         writer.writeheader()
         writer.writerows(rewrite_csv)
         self._log_file.truncate()
-
-    def _warn(self, msg):
-        """Warns the user using warnings.warn.
-
-        The stacklevel parameter needs to be 3 to ensure the call to logger.log
-        is the one printed.
-        """
-        if not self._disable_warnings and msg not in self._warned_once:
-            warnings.warn(
-                colorize(msg, 'yellow'), CsvOutputWarning, stacklevel=3)
-        self._warned_once.add(msg)
-        return msg
-
-    def disable_warnings(self):
-        """Disable logger warnings for testing."""
-        self._disable_warnings = True
-
-
-class CsvOutputWarning(UserWarning):
-    """Warning class for CsvOutput."""
-
-    pass

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -43,7 +43,13 @@ class CsvOutput(FileOutput):
 
             if to_csv.keys() != self._fieldnames:
                 self._fieldnames |= to_csv.keys()
-                self.add_key()
+                if set(to_csv.keys()).issubset(self._fieldnames):
+                    for key in self._fieldnames:
+                        if key not in to_csv.keys():
+                            to_csv[key] = ''
+                    self._writer.writerow(to_csv)
+                else:
+                    self.add_key()
             else:
                 self._writer.writerow(to_csv)
 

--- a/src/dowel/simple_outputs.py
+++ b/src/dowel/simple_outputs.py
@@ -60,9 +60,6 @@ class FileOutput(LogOutput, metaclass=abc.ABCMeta):
         mkdir_p(os.path.dirname(file_name))
         # Open the log file in child class
         self._log_file = open(file_name, mode)
-        if mode != "w":
-            self._log_file.seek(0)
-            self._log_file.truncate()
 
     def close(self):
         """Close any files used by the output."""

--- a/src/dowel/simple_outputs.py
+++ b/src/dowel/simple_outputs.py
@@ -60,6 +60,9 @@ class FileOutput(LogOutput, metaclass=abc.ABCMeta):
         mkdir_p(os.path.dirname(file_name))
         # Open the log file in child class
         self._log_file = open(file_name, mode)
+        if mode != "w":
+            self._log_file.seek(0)
+            self._log_file.truncate()
 
     def close(self):
         """Close any files used by the output."""

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -42,18 +42,37 @@ class TestCsvOutput:
         self.csv_output.record(self.tabular)
         self.tabular.record('foo', foo * 2)
         self.tabular.record('bar', bar * 2)
+        self.csv_output.record(self.tabular)
 
-        with pytest.warns(CsvOutputWarning):
-            self.csv_output.record(self.tabular)
-
-        # this should not produce a warning, because we only warn once
         self.csv_output.record(self.tabular)
 
         self.csv_output.dump()
 
         correct = [
-            {'foo': str(foo)},
-            {'foo': str(foo * 2)},
+            {'foo': str(foo), 'bar': ''},
+            {'foo': str(foo * 2), 'bar': str(bar * 2)},
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    def test_record_inconsistent_2(self):
+        foo = 1
+        bar = 10
+        baz = 100
+        self.tabular.record('foo', foo)
+        self.tabular.record('bar', bar)
+        self.csv_output.record(self.tabular)
+        self.tabular.record('bar', bar * 2)
+        self.tabular.record('baz', baz * 2)
+        self.csv_output.record(self.tabular)
+        self.tabular.record('foo', foo * 4)
+        self.csv_output.record(self.tabular)
+
+        self.csv_output.dump()
+
+        correct = [
+            {'foo': str(foo), 'bar': str(bar), 'baz': ''},
+            {'foo': '', 'bar': str(bar * 2), 'baz': str(baz * 2)},
+            {'foo': str(foo * 4), 'bar': '', 'baz': ''},
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -4,7 +4,6 @@ import tempfile
 import pytest
 
 from dowel import CsvOutput, TabularInput
-from dowel.csv_output import CsvOutputWarning
 
 
 class TestCsvOutput:
@@ -90,19 +89,6 @@ class TestCsvOutput:
     def test_unacceptable_type(self):
         with pytest.raises(ValueError):
             self.csv_output.record('foo')
-
-    def test_disable_warnings(self):
-        foo = 1
-        bar = 10
-        self.tabular.record('foo', foo)
-        self.csv_output.record(self.tabular)
-        self.tabular.record('foo', foo * 2)
-        self.tabular.record('bar', bar * 2)
-
-        self.csv_output.disable_warnings()
-
-        # this should not produce a warning, because we disabled warnings
-        self.csv_output.record(self.tabular)
 
     def assert_csv_matches(self, correct):
         """Check the first row of a csv file and compare it to known values."""


### PR DESCRIPTION
## Changes:
- Fix for [rlworkgroup#45](https://github.com/rlworkgroup/dowel/issues/45) by rewriting csv
- Changed file open mode from 'w' to 'r+' for csv_output. 
- Changed 'test_inconsistent_record' and added 'test_inconsistent_record' in 'test_csv_output.py'

I was unable to test because of windows temp file permission issues but I believe that my solution is at least conceptually valid